### PR TITLE
Update README.md to reflect install process

### DIFF
--- a/pytorch_binding/README.md
+++ b/pytorch_binding/README.md
@@ -32,6 +32,15 @@ cd pytorch_binding
 python setup.py install
 ```
 
+If you try the above and get a dlopen error on OSX with anaconda3 (as recommended by pytorch):
+```
+cd ../pytorch_binding
+python setup.py install
+cd ../build
+cp libwarpctc.dylib /Users/$WHOAMI/anaconda3/lib
+```
+This will resolve the library not loaded error. This can be easily modified to work with other python installs if needed.
+
 Example to use the bindings below.
 
 ```python


### PR DESCRIPTION
Fixes a major problem with the original install process - ffi couldn't find the warpctc library (this may not be exclusive to OSX with anaconda). Might be helpful to others :)

NOTE: This worked for me, I would welcome for others to try it and make sure it also worked for them.