### PR TITLE
force cpu tensor

### DIFF
--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -26,7 +26,7 @@ class _CTC(Function):
         loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
         grads = torch.zeros(acts.size()).type_as(acts)
         minibatch_size = acts.size(1)
-        costs = torch.zeros(minibatch_size)
+        costs = torch.zeros(minibatch_size).cpu()
         loss_func(acts,
                   grads,
                   labels,


### PR DESCRIPTION
If have `torch.set_default_tensor_type('torch.cuda.FloatTensor')` somewhere else, there will be a data type mismatch error (which too me a lot of time to debug lol). Now force costs to be a cpu tensor.