### PR TITLE
Incorporate fixes for gradients

### DIFF
--- a/pytorch_binding/tests/test.py
+++ b/pytorch_binding/tests/test.py
@@ -12,6 +12,7 @@ places = 5
 
 use_cuda = torch.cuda.is_available()
 
+
 def run_grads(label_sizes, labels, probs, sizes):
     probs = Variable(probs, requires_grad=True)
     cost = ctc_loss(probs, labels, sizes, label_sizes)
@@ -24,9 +25,9 @@ def run_grads(label_sizes, labels, probs, sizes):
         gpu_cost = cost.data[0]
     else:
         gpu_cost = cpu_cost
-    grads = probs.grad
+    grads = probs.grad * probs.grad.size(1)
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
-    return cpu_cost, gpu_cost
+    return cpu_cost * probs.size(1), gpu_cost * probs.size(1)
 
 
 class TestCases(unittest.TestCase):

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -36,8 +36,9 @@ class _CTC(Function):
                   act_lens,
                   minibatch_size,
                   costs)
-        costs = torch.FloatTensor([costs.sum()])
+        costs = torch.FloatTensor([costs.sum()]) / acts.size(1)
         ctx.grads = Variable(grads)
+        ctx.grads /= ctx.grads.size(1)
         return costs
 
     @staticmethod


### PR DESCRIPTION
With the new changes to support 0.4, the gradients broke (highlighted by the changes [here](https://github.com/espnet/espnet/pull/105). I've incorporated the changes into the wrapper, however this also means breaking changes for other repos that use this.