### PR TITLE
Flag to compute the average cost instead of the sum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_35,code=sm_35")
 
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_50,code=sm_50")
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_52,code=sm_52")
+IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
+  SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES")
+ENDIF()
 
 IF (CUDA_VERSION GREATER 7.6)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_60,code=sm_60")
@@ -75,7 +78,7 @@ IF (WITH_GPU)
     MESSAGE(STATUS "Building shared library with GPU support")
 
     CUDA_ADD_LIBRARY(warpctc SHARED src/ctc_entrypoint.cu src/reduce.cu)
-    IF (!Torch_FOUND) 
+    IF (!Torch_FOUND)
         TARGET_LINK_LIBRARIES(warpctc ${CUDA_curand_LIBRARY})
     ENDIF()
 
@@ -161,5 +164,3 @@ ELSE()
     ENDIF()
 
 ENDIF()
-
-

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -35,7 +35,7 @@ class _CTC(Function):
                   minibatch_size,
                   costs)
         self.grads = grads
-        self.costs = torch.FloatTensor([costs.sum()])
+        self.costs = torch.FloatTensor(costs)
         return self.costs
 
     def backward(self, grad_output):


### PR DESCRIPTION
Hi,

I think this little pull request will be very useful to many. I usually prefer to compute the avg loss across all timesteps and batch examples, instead of the sum of the loss.

This makes the loss value (and gradients) less sensible to the batch size and the length of the samples.

The option is disabled by default, for back-compatibility reasons, and has the name `size_average' as other losses in PyTorch.