### PR TITLE
Fix batch and length normalization, add tests, replace distutils with setuptools

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -2,7 +2,7 @@
 import os
 import platform
 import sys
-from distutils.core import setup
+from setuptools import setup
 
 from torch.utils.ffi import create_extension
 

--- a/pytorch_binding/tests/test.py
+++ b/pytorch_binding/tests/test.py
@@ -3,42 +3,70 @@ Tests are based on the torch7 bindings for warp-ctc. Reference numbers are also 
 """
 import unittest
 
+import numpy as np
 import torch
 from torch.autograd import Variable
 from warpctc_pytorch import CTCLoss
 
-ctc_loss = CTCLoss()
 places = 5
 
 use_cuda = torch.cuda.is_available()
 
-def run_grads(label_sizes, labels, probs, sizes):
-    probs = Variable(probs, requires_grad=True)
-    cost = ctc_loss(probs, labels, sizes, label_sizes)
-    cost.backward()
-    cpu_cost = cost.data[0]
-    if use_cuda:
-        probs = Variable(probs.data.cuda(), requires_grad=True)
-        cost = ctc_loss(probs, labels, sizes, label_sizes)
-        cost.backward()
-        gpu_cost = cost.data[0]
-    else:
-        gpu_cost = cpu_cost
-    grads = probs.grad
-    print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
-    return cpu_cost, gpu_cost
-
 
 class TestCases(unittest.TestCase):
+    def _run_grads(self, label_sizes, labels, probs, sizes, size_average=False,
+                   length_average=False):
+        ctc_loss = CTCLoss(size_average=size_average,
+                           length_average=length_average)
+        probs = Variable(probs, requires_grad=True)
+        cost = ctc_loss(probs, labels, sizes, label_sizes)
+        cost.backward()
+        cpu_cost = cost.data[0]
+        cpu_grad = probs.grad
+        if use_cuda:
+            probs = Variable(probs.data.cuda(), requires_grad=True)
+            cost = ctc_loss(probs, labels, sizes, label_sizes)
+            cost.backward()
+            gpu_cost = cost.data[0]
+            gpu_grad = probs.grad
+        else:
+            gpu_cost = cpu_cost
+            gpu_grad = cpu_grad
+        grads = probs.grad
+        print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
+        self.assertEqual(cpu_cost, gpu_cost)
+        np.testing.assert_almost_equal(
+            cpu_grad.numpy(), gpu_grad.cpu().numpy(), decimal=places)
+        return cpu_cost, cpu_grad.numpy()
+
+    def _test_normalization(self, label_sizes, labels, probs, sizes,
+                            expected_cost, expected_grad, size_average=False,
+                            length_average=False):
+        cpu_cost, cpu_grad = self._run_grads(
+            label_sizes, labels, probs, sizes, size_average=size_average,
+            length_average=length_average)
+        self.assertAlmostEqual(cpu_cost, expected_cost, places)
+        np.testing.assert_almost_equal(expected_grad, cpu_grad, places)
+
     def test_simple(self):
-        probs = torch.FloatTensor([[[0.1, 0.6, 0.1, 0.1, 0.1], [0.1, 0.1, 0.6, 0.1, 0.1]]]).transpose(0, 1).contiguous()
+        probs = torch.FloatTensor(
+            [[[0.1, 0.6, 0.1, 0.1, 0.1], [0.1, 0.1, 0.6, 0.1, 0.1]]]).transpose(
+            0, 1).contiguous()
         labels = Variable(torch.IntTensor([1, 2]))
         label_sizes = Variable(torch.IntTensor([2]))
         sizes = Variable(torch.IntTensor([2]))
-        cpu_cost, gpu_cost = run_grads(label_sizes, labels, probs, sizes)
+        # Basic checks
+        cpu_cost, cpu_grad = self._run_grads(label_sizes, labels, probs, sizes)
         expected_cost = 2.4628584384918
-        self.assertEqual(cpu_cost, gpu_cost)
         self.assertAlmostEqual(cpu_cost, expected_cost, places)
+        # Check normalization by batch size
+        self._test_normalization(
+            label_sizes, labels, probs, sizes, cpu_cost, cpu_grad,
+            size_average=True)
+        # Check normalization by total frames
+        self._test_normalization(
+            label_sizes, labels, probs, sizes, cpu_cost / 2, cpu_grad / 2,
+            length_average=True)
 
     def test_medium(self):
         probs = torch.FloatTensor([
@@ -49,10 +77,18 @@ class TestCases(unittest.TestCase):
         labels = Variable(torch.IntTensor([1, 2, 1, 2]))
         label_sizes = Variable(torch.IntTensor([2, 2]))
         sizes = Variable(torch.IntTensor([2, 2]))
-        cpu_cost, gpu_cost = run_grads(label_sizes, labels, probs, sizes)
+        # Basic checks
+        cpu_cost, cpu_grad = self._run_grads(label_sizes, labels, probs, sizes)
         expected_cost = 6.0165174007416
-        self.assertEqual(cpu_cost, gpu_cost)
         self.assertAlmostEqual(cpu_cost, expected_cost, places)
+        # Check normalization by batch size
+        self._test_normalization(
+            label_sizes, labels, probs, sizes, cpu_cost / 2, cpu_grad / 2,
+            size_average=True)
+        # Check normalization by total frames
+        self._test_normalization(
+            label_sizes, labels, probs, sizes, cpu_cost / 4, cpu_grad / 4,
+            length_average=True)
 
     def test_medium_stability(self):
         multiplier = 200
@@ -64,10 +100,18 @@ class TestCases(unittest.TestCase):
         labels = Variable(torch.IntTensor([1, 2, 1, 2]))
         label_sizes = Variable(torch.IntTensor([2, 2]))
         sizes = Variable(torch.IntTensor([2, 2]))
-        cpu_cost, gpu_cost = run_grads(label_sizes, labels, probs, sizes)
+        # Basic checks
+        cpu_cost, cpu_grad = self._run_grads(label_sizes, labels, probs, sizes)
         expected_cost = 199.96618652344
-        self.assertEqual(cpu_cost, gpu_cost)
         self.assertAlmostEqual(cpu_cost, expected_cost, places)
+        # Check normalization by batch size
+        self._test_normalization(
+            label_sizes, labels, probs, sizes, cpu_cost / 2, cpu_grad / 2,
+            size_average=True)
+        # Check normalization by total frames
+        self._test_normalization(
+            label_sizes, labels, probs, sizes, cpu_cost / 4, cpu_grad / 4,
+            length_average=True)
 
     def test_empty_label(self):
         probs = torch.FloatTensor([
@@ -78,10 +122,18 @@ class TestCases(unittest.TestCase):
         labels = Variable(torch.IntTensor([1, 2]))
         label_sizes = Variable(torch.IntTensor([2, 0]))
         sizes = Variable(torch.IntTensor([2, 2]))
-        cpu_cost, gpu_cost = run_grads(label_sizes, labels, probs, sizes)
+        # Basic checks
+        cpu_cost, cpu_grad = self._run_grads(label_sizes, labels, probs, sizes)
         expected_cost = 6.416517496109
-        self.assertEqual(cpu_cost, gpu_cost)
         self.assertAlmostEqual(cpu_cost, expected_cost, places)
+        # Check normalization by batch size
+        self._test_normalization(
+            label_sizes, labels, probs, sizes, cpu_cost / 2, cpu_grad / 2,
+            size_average=True)
+        # Check normalization by total frames
+        self._test_normalization(
+            label_sizes, labels, probs, sizes, cpu_cost / 4, cpu_grad / 4,
+            length_average=True)
 
 
 if __name__ == '__main__':

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -22,7 +22,8 @@ _import_symbols(locals())
 
 class _CTC(Function):
     @staticmethod
-    def forward(ctx, acts, labels, act_lens, label_lens, size_average=False):
+    def forward(ctx, acts, labels, act_lens, label_lens, size_average=False,
+                length_average=False):
         is_cuda = True if acts.is_cuda else False
         acts = acts.contiguous()
         loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
@@ -36,24 +37,41 @@ class _CTC(Function):
                   act_lens,
                   minibatch_size,
                   costs)
-        if size_average:
-            # Compute the avg. log-probability per frame and batch sample.
-            costs = torch.FloatTensor([costs.mean()])
-        else:
-            costs = torch.FloatTensor([costs.sum()])
+
+        costs = torch.FloatTensor([costs.sum()])
+
+        if length_average:
+            # Compute the avg. log-probability per batch sample and frame.
+            total_length = torch.prod(act_lens)
+            grads = grads / total_length
+            costs = costs / total_length
+        elif size_average:
+            # Compute the avg. log-probability per batch sample.
+            grads = grads / minibatch_size
+            costs = costs / minibatch_size
+
         ctx.grads = Variable(grads)
         return costs
 
     @staticmethod
     def backward(ctx, grad_output):
-        return ctx.grads, None, None, None, None
+        return ctx.grads, None, None, None, None, None
 
 
 class CTCLoss(Module):
-    def __init__(self, size_average=False):
+    """
+    Parameters:
+        size_average (bool): normalize the loss by the batch size
+            (default: `False`)
+        length_average (bool): normalize the loss by the total number of frames
+            in the batch. If `True`, supersedes `size_average`
+            (default: `False`)
+    """
+    def __init__(self, size_average=False, length_average=False):
         super(CTCLoss, self).__init__()
         self.ctc = _CTC.apply
         self.size_average = size_average
+        self.length_average = length_average
 
     def forward(self, acts, labels, act_lens, label_lens):
         """
@@ -66,4 +84,5 @@ class CTCLoss(Module):
         _assert_no_grad(labels)
         _assert_no_grad(act_lens)
         _assert_no_grad(label_lens)
-        return self.ctc(acts, labels, act_lens, label_lens, self.size_average)
+        return self.ctc(acts, labels, act_lens, label_lens, self.size_average,
+                        self.length_average)

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -42,7 +42,7 @@ class _CTC(Function):
 
         if length_average:
             # Compute the avg. log-probability per batch sample and frame.
-            total_length = torch.prod(act_lens)
+            total_length = torch.sum(act_lens)
             grads = grads / total_length
             costs = costs / total_length
         elif size_average:


### PR DESCRIPTION
In my previous PR there was a bug: the value of the normalized loss function was correct, but the gradients were those of the unnormalized version. This fixes that issue.

The user can select to normalize the loss (and gradients) w.r.t. the batch size (`size_average=True`) or w.r.t. the total number of frames in the batch (`length_average=True`). The latter overrides the former.

I updated the tests to prevent dummy mistakes like these.

In addition, Distutils support soon will be deprecated in pip, currently this warning is shown when one tries to uninstall the package with `pip uninstall`:

```
DEPRECATION: Uninstalling a distutils installed project (warpctc-pytorch) has been deprecated and will be removed in a future version. This is due to the fact that uninstalling a distutils project will only partially uninstall the project.
```

