### PR TITLE
Remove auto-generated parts from __init__.py

### DIFF
--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -3,20 +3,8 @@ import warpctc_pytorch as warp_ctc
 from torch.autograd import Function
 from torch.nn import Module
 from torch.nn.modules.loss import _assert_no_grad
-from torch.utils.ffi import _wrap_function
-from ._warp_ctc import lib as _lib, ffi as _ffi
 
-__all__ = []
-
-
-def _import_symbols(locals):
-    for symbol in dir(_lib):
-        fn = getattr(_lib, symbol)
-        locals[symbol] = _wrap_function(fn, _ffi)
-        __all__.append(symbol)
-
-
-_import_symbols(locals())
+from ._warp_ctc import *
 
 
 class _CTC(Function):
@@ -53,7 +41,7 @@ class CTCLoss(Module):
         act_lens: Tensor of size (batch) containing size of each output sequence from the network
         act_lens: Tensor of (batch) containing label length of each example
         """
-        assert len(labels.size()) == 1 # labels must be 1 dimensional
+        assert len(labels.size()) == 1  # labels must be 1 dimensional
         _assert_no_grad(labels)
         _assert_no_grad(act_lens)
         _assert_no_grad(label_lens)


### PR DESCRIPTION
This is causing error on python2. I confirmed this works on both python2 and python3.

fixes https://github.com/SeanNaren/warp-ctc/pull/12#issuecomment-370378898

Autogenrated `warpctc_pytorch/_warp_ctc/__init__.py`:

```
cat warpctc_pytorch/_warp_ctc/__init__.py
```
```py
from torch.utils.ffi import _wrap_function
from .__warp_ctc import lib as _lib, ffi as _ffi

__all__ = []
def _import_symbols(locals):
    for symbol in dir(_lib):
        fn = getattr(_lib, symbol)
        if callable(fn):
            locals[symbol] = _wrap_function(fn, _ffi)
        else:
            locals[symbol] = fn
        __all__.append(symbol)

_import_symbols(locals())
```

EDIT: I'm opening a PR against https://github.com/SeanNaren/warp-ctc/pull/17.