### PR TITLE
Fix installation issue and tests

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -2,7 +2,7 @@
 import os
 import platform
 import sys
-from setuptools import setup
+from setuptools import setup, find_packages
 
 from torch.utils.ffi import create_extension
 
@@ -59,6 +59,6 @@ setup(
     author="Jared Casper, Sean Naren",
     author_email="jared.casper@baidu.com, sean.narenthiran@digitalreasoning.com",
     license="Apache",
-    packages=["warpctc_pytorch"],
+    packages=find_packages(),
     ext_modules=[ffi],
 )

--- a/pytorch_binding/tests/test.py
+++ b/pytorch_binding/tests/test.py
@@ -22,13 +22,13 @@ class TestCases(unittest.TestCase):
         cost = ctc_loss(probs, labels, sizes, label_sizes)
         cost.backward()
         cpu_cost = cost.data[0]
-        cpu_grad = probs.grad
+        cpu_grad = probs.grad.data
         if use_cuda:
             probs = Variable(probs.data.cuda(), requires_grad=True)
             cost = ctc_loss(probs, labels, sizes, label_sizes)
             cost.backward()
             gpu_cost = cost.data[0]
-            gpu_grad = probs.grad
+            gpu_grad = probs.grad.data
         else:
             gpu_cost = cpu_cost
             gpu_grad = cpu_grad


### PR DESCRIPTION
`_warp_ctc` module wasn't correctly installed by `python setup.py install`. Use setuptools to collect modules to be installed.

fixes espnet/espnet#115 (comment).

Also fixed tests.

```
In [1]: from setuptools import find_packages

In [2]: find_packages()
Out[2]: ['warpctc_pytorch', 'warpctc_pytorch._warp_ctc']
```

Fixes #30 