### PR TITLE
MacOSX needs different c++ flag

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -6,7 +6,13 @@ from setuptools import setup, find_packages
 
 from torch.utils.ffi import create_extension
 
-extra_compile_args = ['-std=c++11', '-fPIC']
+if sys.platform == 'darwin':
+    extra_compile_args = ['--stdlib=libc++']
+else:
+    extra_compile_args = ['-std=c++']
+
+extra_compile_args += ['-fPIC']
+
 warp_ctc_path = "../build"
 
 if "CUDA_HOME" not in os.environ:


### PR DESCRIPTION
This PR fixes issue #26 
The compiler flag needs to be different on MacOSX platform as the standard LLVM/CLang compiler does not understand the `c++` flag.