### PR TITLE
Fix compilation of tests on Debian with gcc-5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,12 +86,13 @@ IF (WITH_GPU)
         TARGET_LINK_LIBRARIES(warpctc ${CUDA_curand_LIBRARY})
     ENDIF()
 
-    add_executable(test_cpu tests/test_cpu.cpp )
+    add_executable(test_cpu tests/test_cpu.cpp tests/random.cpp )
     TARGET_LINK_LIBRARIES(test_cpu warpctc)
     SET_TARGET_PROPERTIES(test_cpu PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
 
-    cuda_add_executable(test_gpu tests/test_gpu.cu)
+    cuda_add_executable(test_gpu tests/test_gpu.cu tests/random.cpp )
     TARGET_LINK_LIBRARIES(test_gpu warpctc ${CUDA_curand_LIBRARY})
+    SET_TARGET_PROPERTIES(test_gpu PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
 
     INSTALL(TARGETS warpctc
             RUNTIME DESTINATION "bin"

--- a/tests/random.cpp
+++ b/tests/random.cpp
@@ -1,0 +1,32 @@
+#include <vector>
+#include <random>
+
+
+std::vector<float>
+genActs(int size) {
+    std::vector<float> arr(size);
+    std::mt19937 gen(0);
+    std::uniform_real_distribution<> dis(0, 1);
+    for(int i = 0; i < size; ++i)
+        arr[i] = dis(gen);
+    return arr;
+}
+
+std::vector<int>
+genLabels(int alphabet_size, int L) {
+    std::vector<int> label(L);
+
+    std::mt19937 gen(1);
+    std::uniform_int_distribution<> dis(1, alphabet_size - 1);
+
+    for(int i = 0; i < L; ++i) {
+        label[i] = dis(gen);
+    }
+    // guarantee repeats for testing
+    if (L >= 3) {
+        label[L / 2] = label[L / 2 + 1];
+        label[L / 2 - 1] = label[L / 2];
+    }
+    return label;
+}
+

--- a/tests/test.h
+++ b/tests/test.h
@@ -2,7 +2,9 @@
 
 #include <stdexcept>
 #include <vector>
-#include <random>
+#include <limits>
+#include <numeric>
+
 
 #include <ctc.h>
 
@@ -25,33 +27,8 @@ inline void throw_on_error(cudaError_t error, const char* message) {
 
 #endif
 
-std::vector<float>
-genActs(int size) {
-    std::vector<float> arr(size);
-    std::mt19937 gen(0);
-    std::uniform_real_distribution<> dis(0, 1);
-    for(int i = 0; i < size; ++i)
-        arr[i] = dis(gen);
-    return arr;
-}
-
-std::vector<int>
-genLabels(int alphabet_size, int L) {
-    std::vector<int> label(L);
-
-    std::mt19937 gen(1);
-    std::uniform_int_distribution<> dis(1, alphabet_size - 1);
-
-    for(int i = 0; i < L; ++i) {
-        label[i] = dis(gen);
-    }
-    // guarantee repeats for testing
-    if (L >= 3) {
-        label[L / 2] = label[L / 2 + 1];
-        label[L / 2 - 1] = label[L / 2];
-    }
-    return label;
-}
+std::vector<float> genActs(int size);
+std::vector<int> genLabels(int alphabet_size, int L);
 
 float rel_diff(const std::vector<float>& grad,
                const std::vector<float>& num_grad) {

--- a/tests/test_gpu.cu
+++ b/tests/test_gpu.cu
@@ -1,5 +1,4 @@
 #include <cmath>
-#include <random>
 #include <tuple>
 #include <vector>
 #include <iostream>


### PR DESCRIPTION
On Debian with gcc-5, the random header does not like to be
compiled with nvcc. Including random in .cu results in errors
in avx512-headers.
Thus, this moves the random bits out of the test.h included by the
test_gpu.cu .