### PR TITLE
Fixes ctc loss input checking

### DIFF
--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -12,51 +12,42 @@ class _CTC(Function):
     @staticmethod
     def forward(ctx, acts, labels, act_lens, label_lens, size_average=False,
                 length_average=False):
-        with torch.no_grad():
+        # with torch.no_grad():
 
-            is_cuda = True if acts.is_cuda else False
-            acts = acts.contiguous()
-            loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
-            grads = torch.zeros(acts.size()).type_as(acts)
-            minibatch_size = acts.size(1)
+        is_cuda = True if acts.is_cuda else False
+        acts = acts.contiguous()
+        loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
+        grads = torch.zeros(acts.size()).type_as(acts)
+        minibatch_size = acts.size(1)
 
-            # Output for debugging
-            print("_CTC forward function: minibatch size: " + str(minibatch_size))
+        # Output for debugging
+        # print("_CTC forward function: minibatch size: " + str(minibatch_size))
 
-            costs = torch.zeros(minibatch_size).cpu()
-            loss_func(acts,
-                      grads,
-                      labels,
-                      label_lens,
-                      act_lens,
-                      minibatch_size,
-                      costs)
+        costs = torch.zeros(minibatch_size).cpu()
+        loss_func(acts,
+                  grads,
+                  labels,
+                  label_lens,
+                  act_lens,
+                  minibatch_size,
+                  costs)
 
-            # Output for debugging
-            print("_CTC forward function: costs before summation: " + str(costs))
+        # Output for debugging
+        # print("_CTC forward function: costs before summation: " + str(costs))
 
-            costs = torch.FloatTensor([costs.sum()])
+        costs = torch.FloatTensor([costs.sum()])
 
-            if length_average:
-                # Compute the avg. log-probability per batch sample and frame.
-                total_length = torch.sum(act_lens)
-                grads = grads / total_length
-                costs = costs / total_length
-            elif size_average:
-                # Compute the avg. log-probability per batch sample.
-                grads = grads / minibatch_size
-                costs = costs / minibatch_size
+        if length_average:
+            # Compute the avg. log-probability per batch sample and frame.
+            total_length = torch.sum(act_lens)
+            grads = grads / total_length
+            costs = costs / total_length
+        elif size_average:
+            # Compute the avg. log-probability per batch sample.
+            grads = grads / minibatch_size
+            costs = costs / minibatch_size
 
-            # Replaced with " torch.no_grad()" around the whole function body
-            # The goal was to not track the computation with autograd appearantly.
-            # https://stackoverflow.com/questions/49837638/what-is-volatile-variable-in-pytorch
-            # This is now done differently
-            # https://pytorch.org/2018/04/22/0_4_0-migration-guide.html
-            # See: https://discuss.pytorch.org/t/torch-no-grad/12296
-            # https://github.com/SeanNaren/deepspeech.pytorch/issues/277
-            # https://discuss.pytorch.org/t/why-volatility-changed-after-operation-parameter-parameter-0-01-parameter-grad/11639
-            # ctx.grads = Variable(grads, volatile=True)
-            ctx.grads = grads
+            ctx.grads = Variable(grads, volatile=True)
 
             # Debugging output
             # print(">>>  ctx.grads: " + str(ctx.grads))

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -12,33 +12,49 @@ class _CTC(Function):
     @staticmethod
     def forward(ctx, acts, labels, act_lens, label_lens, size_average=False,
                 length_average=False):
-        is_cuda = True if acts.is_cuda else False
-        acts = acts.contiguous()
-        loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
-        grads = torch.zeros(acts.size()).type_as(acts)
-        minibatch_size = acts.size(1)
-        costs = torch.zeros(minibatch_size).cpu()
-        loss_func(acts,
-                  grads,
-                  labels,
-                  label_lens,
-                  act_lens,
-                  minibatch_size,
-                  costs)
+        with torch.no_grad():
 
-        costs = torch.FloatTensor([costs.sum()])
+            is_cuda = True if acts.is_cuda else False
+            acts = acts.contiguous()
+            loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
+            grads = torch.zeros(acts.size()).type_as(acts)
+            minibatch_size = acts.size(1)
+            costs = torch.zeros(minibatch_size).cpu()
+            loss_func(acts,
+                      grads,
+                      labels,
+                      label_lens,
+                      act_lens,
+                      minibatch_size,
+                      costs)
 
-        if length_average:
-            # Compute the avg. log-probability per batch sample and frame.
-            total_length = torch.sum(act_lens)
-            grads = grads / total_length
-            costs = costs / total_length
-        elif size_average:
-            # Compute the avg. log-probability per batch sample.
-            grads = grads / minibatch_size
-            costs = costs / minibatch_size
+            costs = torch.FloatTensor([costs.sum()])
 
-        ctx.grads = Variable(grads, volatile=True)
+            if length_average:
+                # Compute the avg. log-probability per batch sample and frame.
+                total_length = torch.sum(act_lens)
+                grads = grads / total_length
+                costs = costs / total_length
+            elif size_average:
+                # Compute the avg. log-probability per batch sample.
+                grads = grads / minibatch_size
+                costs = costs / minibatch_size
+
+            # Replaced with " torch.no_grad()" around the whole function body
+            # The goal was to not track the computation with autograd appearantly.
+            # https://stackoverflow.com/questions/49837638/what-is-volatile-variable-in-pytorch
+            # This is now done differently
+            # https://pytorch.org/2018/04/22/0_4_0-migration-guide.html
+            # See: https://discuss.pytorch.org/t/torch-no-grad/12296
+            # https://github.com/SeanNaren/deepspeech.pytorch/issues/277
+            # https://discuss.pytorch.org/t/why-volatility-changed-after-operation-parameter-parameter-0-01-parameter-grad/11639
+            # ctx.grads = Variable(grads, volatile=True)
+            ctx.grads = grads
+
+            # Debugging output
+            # print(">>>  ctx.grads: " + str(ctx.grads))
+            # print(">>>  ctx.grads.requires_grad: " + str(ctx.grads.requires_grad))
+
         return costs
 
     @staticmethod

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -19,6 +19,10 @@ class _CTC(Function):
             loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
             grads = torch.zeros(acts.size()).type_as(acts)
             minibatch_size = acts.size(1)
+
+            # Output for debugging
+            print("_CTC forward function: minibatch size: " + str(minibatch_size))
+
             costs = torch.zeros(minibatch_size).cpu()
             loss_func(acts,
                       grads,
@@ -27,6 +31,9 @@ class _CTC(Function):
                       act_lens,
                       minibatch_size,
                       costs)
+
+            # Output for debugging
+            print("_CTC forward function: costs before summation: " + str(costs))
 
             costs = torch.FloatTensor([costs.sum()])
 
@@ -84,7 +91,26 @@ class CTCLoss(Module):
         act_lens: Tensor of size (batch) containing size of each output sequence from the network
         label_lens: Tensor of (batch) containing label length of each example
         """
-        assert len(labels.size()) == 1  # labels must be 1 dimensional
+
+        print("labels.size()" + str(labels.size()))
+        if not len(labels.size()) == 1:
+            raise RuntimeError("Error: the labels must be one dimensional and contain\n" +
+                               "all label sequences in the examples of the batch concatenated." +
+                               "\nBut got however labels.size(): " + str(labels.size()) + "\n" +
+                               "which is not the right usage.")
+        #assert len(labels.size()) == 1  # labels must be 1 dimensional
+
+        sum_label_lens = torch.sum(label_lens)
+        # label_lens contains the lengths of the label sequences (sub-ranges)
+        # that are concatenated together in labels. Hence the sum of label_lens
+        # should be the length of labels
+        if not sum_label_lens == len(labels):
+            raise RuntimeError("Error: length of labels is: " + str(len(labels)) +
+                               " but sum of label lengths in " + str(labels) +
+                               " is " + str(sum_label_lens) + "." +
+                               "\nPlease make sure the label lengths" +
+                               " add up to the number of labels")
+
         _assert_no_grad(labels)
         _assert_no_grad(act_lens)
         _assert_no_grad(label_lens)


### PR DESCRIPTION
Dear Sean,
I started using your warp_ctc interface code and I enjoy it a lot. It took me some time however to find out how exactly to use the interface. Eventually I was able to reproduce the examples from https://github.com/baidu-research/warp-ctc/blob/master/torch_binding/TUTORIAL.md 
I thought it good to add some more explanatory checks to the input of the CTCLoss forward function, which is the main entrypoint really as per my understanding. I added checks:

 Added additional and more clear checks of the correctness of the input
    to the CTCLoss forward function:
    
    1. Check that the labels input has dimensionality 1. There was already
       an assertion for this, but now replaced this with an actual explanatory
       runtime error that explains that a 1-dimensional label sequence tensor
       containing the label sequences for all tensors concatenated is expected.
    
    2. Check that the sum of the label_length in label_lengths is equal to the
       length of the labels tensor. This must be the case, since label_length
       essentially how labels is to be segmented to retrieve the original label
       sequences for the different examples, that were concatenated for the sake
       of computation.

I think these checks add to the easy of use of the function and will provide instructions to the user that help overcoming the problem when the interface is not correctly used. Right now in certain cases, for example when the second check is not satisfied, the program still runs, but the output is not properly interpretable. 
See https://discuss.pytorch.org/t/ctcloss-dont-work-in-pytorch/13859
"
Can you post a minimal gist or so to reproduce?
(I.e. precompute outputs and target and just have your ctc application.)
**It works for me but acts funny on invalid inputs etc.**

Best regards Thomas
"
I think checking the input for non-valid combinations of tensors will be a good way to improve the discoverability of the correct use of the code, and solve some of the problems with wrong output for invalid inputs. 
