### PR TITLE
update

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -7,7 +7,8 @@ from setuptools import setup, find_packages
 from torch.utils.ffi import create_extension
 import torch
 
-extra_compile_args = ['-std=c++11', '-fPIC']
+#extra_compile_args = ['-std=c++11', '-fPIC']
+extra_compile_args = ['-std=c99', '-fPIC']
 warp_ctc_path = "../build"
 
 if torch.cuda.is_available() or "CUDA_HOME" in os.environ:

--- a/pytorch_binding/src/binding.cpp
+++ b/pytorch_binding/src/binding.cpp
@@ -20,6 +20,8 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
                         THIntTensor *label_sizes,
                         THIntTensor *sizes,
                         int minibatch_size,
+                        int blanklabel_index,
+                        int num_threads,
                         THFloatTensor *costs) {
 
     float *probs_ptr = probs->storage->data + probs->storageOffset;
@@ -38,7 +40,8 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
     ctcOptions options;
     memset(&options, 0, sizeof(options));
     options.loc = CTC_CPU;
-    options.num_threads = 0; // will use default number of threads
+    options.blank_label = blanklabel_index;
+    options.num_threads = num_threads; // will use given number of threads
 
 #if defined(CTC_DISABLE_OMP) || defined(APPLE)
     // have to use at least one
@@ -68,6 +71,7 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
                            THIntTensor *label_sizes,
                            THIntTensor *sizes,
                            int minibatch_size,
+                           int blanklabel_index,
                            THFloatTensor *costs) {
 
        float *probs_ptr = probs->storage->data + probs->storageOffset;
@@ -86,6 +90,7 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
        ctcOptions options;
        memset(&options, 0, sizeof(options));
        options.loc = CTC_GPU;
+       options.blank_label = blanklabel_index;
        options.stream = THCState_getCurrentStream(state);
 
        size_t gpu_size_bytes;

--- a/pytorch_binding/tests/test_cpu.py
+++ b/pytorch_binding/tests/test_cpu.py
@@ -17,9 +17,9 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     blank_label=0,
-                     num_threads=0,
-                     costs=costs)
+                     0,
+                     0,
+                     costs)
     print('CPU_cost: %f' % costs.sum())
 
 
@@ -42,9 +42,9 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     blank_label=0,
-                     num_threads=0,
-                     costs=costs)
+                     0,
+                     0,
+                     costs)
     print('CPU_cost: %f' % costs.sum())
 
 
@@ -66,9 +66,9 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     blank_label=0,
-                     num_threads=0,
-                     costs=costs)
+                     0,
+                     0,
+                     costs)
     print('CPU_cost: %f' % costs.sum())
 
 

--- a/pytorch_binding/tests/test_cpu.py
+++ b/pytorch_binding/tests/test_cpu.py
@@ -17,6 +17,8 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
+                     blank_label=0,
+                     num_threads=0,
                      costs)
     print('CPU_cost: %f' % costs.sum())
 
@@ -40,6 +42,8 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
+                     blank_label=0,
+                     num_threads=0,
                      costs)
     print('CPU_cost: %f' % costs.sum())
 
@@ -62,6 +66,8 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
+                     blank_label=0,
+                     num_threads=0,
                      costs)
     print('CPU_cost: %f' % costs.sum())
 

--- a/pytorch_binding/tests/test_cpu.py
+++ b/pytorch_binding/tests/test_cpu.py
@@ -19,7 +19,7 @@ def test_simple():
                      minibatch_size,
                      blank_label=0,
                      num_threads=0,
-                     costs)
+                     costs=costs)
     print('CPU_cost: %f' % costs.sum())
 
 
@@ -44,7 +44,7 @@ def test_medium(multiplier):
                      minibatch_size,
                      blank_label=0,
                      num_threads=0,
-                     costs)
+                     costs=costs)
     print('CPU_cost: %f' % costs.sum())
 
 
@@ -68,7 +68,7 @@ def test_empty_label():
                      minibatch_size,
                      blank_label=0,
                      num_threads=0,
-                     costs)
+                     costs=costs)
     print('CPU_cost: %f' % costs.sum())
 
 

--- a/pytorch_binding/tests/test_gpu.py
+++ b/pytorch_binding/tests/test_gpu.py
@@ -18,9 +18,9 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     blank_label=0,
-                     num_threads=0,
-                     costs=costs)
+                     0,
+                     0,
+                     costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -31,8 +31,8 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     blank_label=0,
-                     costs=costs)
+                     0,
+                     costs)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 
@@ -57,9 +57,9 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     blank_label=0,
-                     num_threads=0,
-                     costs=costs)
+                     0,
+                     0,
+                     costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -70,7 +70,8 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs=costs)
+                     0,
+                     costs)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 
@@ -94,9 +95,9 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     blank_label=0,
-                     num_threads=0,
-                     costs=costs)
+                     0,
+                     0,
+                     costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -107,8 +108,8 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     blank_label=0,
-                     costs=costs)
+                     0,
+                     costs)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 

--- a/pytorch_binding/tests/test_gpu.py
+++ b/pytorch_binding/tests/test_gpu.py
@@ -18,6 +18,8 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
+                     blank_label=0,
+                     num_threads=0,
                      costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
@@ -29,6 +31,7 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
+                     blank_label=0,
                      costs)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
@@ -54,6 +57,8 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
+                     blank_label=0,
+                     num_threads=0,
                      costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
@@ -89,6 +94,8 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
+                     blank_label=0,
+                     num_threads=0,
                      costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
@@ -100,6 +107,7 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
+                     blank_label=0,
                      costs)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))

--- a/pytorch_binding/tests/test_gpu.py
+++ b/pytorch_binding/tests/test_gpu.py
@@ -20,7 +20,7 @@ def test_simple():
                      minibatch_size,
                      blank_label=0,
                      num_threads=0,
-                     costs)
+                     costs=costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -32,7 +32,7 @@ def test_simple():
                      sizes,
                      minibatch_size,
                      blank_label=0,
-                     costs)
+                     costs=costs)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 
@@ -59,7 +59,7 @@ def test_medium(multiplier):
                      minibatch_size,
                      blank_label=0,
                      num_threads=0,
-                     costs)
+                     costs=costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -70,7 +70,7 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs=costs)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 
@@ -96,7 +96,7 @@ def test_empty_label():
                      minibatch_size,
                      blank_label=0,
                      num_threads=0,
-                     costs)
+                     costs=costs)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -108,7 +108,7 @@ def test_empty_label():
                      sizes,
                      minibatch_size,
                      blank_label=0,
-                     costs)
+                     costs=costs)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -9,22 +9,18 @@ from ._warp_ctc import *
 
 class _CTC(Function):
     @staticmethod
-    def forward(ctx, acts, labels, act_lens, label_lens, size_average=False,
+    def forward(ctx, acts, labels, act_lens, label_lens, blank_label=0, num_threads=0, size_average=False,
                 length_average=False):
         is_cuda = True if acts.is_cuda else False
         acts = acts.contiguous()
-        loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
         grads = torch.zeros(acts.size()).type_as(acts)
         minibatch_size = acts.size(1)
         costs = torch.zeros(minibatch_size).cpu()
-        loss_func(acts,
-                  grads,
-                  labels,
-                  label_lens,
-                  act_lens,
-                  minibatch_size,
-                  costs)
-
+        if is_cuda:
+            # num_threads will be negeleted in GPU mode
+            warp_ctc.gpu_ctc(acts, grads,labels, label_lens, act_lens, minibatch_size, blank_label, costs)
+        else:
+            warp_ctc.cpu_ctc(acts, grads,labels, label_lens, act_lens, minibatch_size, blank_label, num_threads, costs)
         costs = torch.FloatTensor([costs.sum()])
 
         if length_average:


### PR DESCRIPTION
change compile args "-std=c++11" to "-std=c99" to fix fail on pytorch0.4

add interface on python for parameter "blank_label"=0 and "num_threads"=0 for more flexible usage.
