### PR TITLE
Update __init__.py

### DIFF
--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -29,7 +29,7 @@ class _CTC(Function):
 
         if length_average:
             # Compute the avg. log-probability per batch sample and frame.
-            total_length = torch.sum(act_lens)
+            total_length = torch.sum(act_lens).item()
             grads = grads / total_length
             costs = costs / total_length
         elif size_average:


### PR DESCRIPTION
Add .item() to sum of lengths to avoid type mismatch on division : 

`RuntimeError: Expected object of type torch.FloatTensor but found type torch.LongTensor for argument #2 'other'`