### PR TITLE
modification for pytorch 0.5.0 and adding blank option

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from torch.utils.ffi import create_extension
 import torch
 
-extra_compile_args = ['-std=c++11', '-fPIC']
+extra_compile_args = ['-std=c++11', '-std=c99', '-fPIC']
 warp_ctc_path = "../build"
 
 if torch.cuda.is_available() or "CUDA_HOME" in os.environ:

--- a/pytorch_binding/src/binding.cpp
+++ b/pytorch_binding/src/binding.cpp
@@ -20,7 +20,8 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
                         THIntTensor *label_sizes,
                         THIntTensor *sizes,
                         int minibatch_size,
-                        THFloatTensor *costs) {
+                        THFloatTensor *costs,
+                        int blank_label) {
 
     float *probs_ptr = probs->storage->data + probs->storageOffset;
     float *grads_ptr;
@@ -39,6 +40,7 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
     memset(&options, 0, sizeof(options));
     options.loc = CTC_CPU;
     options.num_threads = 0; // will use default number of threads
+    options.blank_label = blank_label;
 
 #if defined(CTC_DISABLE_OMP) || defined(APPLE)
     // have to use at least one
@@ -68,7 +70,8 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
                            THIntTensor *label_sizes,
                            THIntTensor *sizes,
                            int minibatch_size,
-                           THFloatTensor *costs) {
+                           THFloatTensor *costs,
+                           int blank_label) {
 
        float *probs_ptr = probs->storage->data + probs->storageOffset;
        float *grads_ptr;
@@ -86,6 +89,7 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
        ctcOptions options;
        memset(&options, 0, sizeof(options));
        options.loc = CTC_GPU;
+       options.blank_label = blank_label;
        options.stream = THCState_getCurrentStream(state);
 
        size_t gpu_size_bytes;

--- a/pytorch_binding/src/binding.cpp
+++ b/pytorch_binding/src/binding.cpp
@@ -15,26 +15,28 @@
 #endif
 
 extern "C" int cpu_ctc(THFloatTensor *probs,
-                        THFloatTensor *grads,
-                        THIntTensor *labels,
-                        THIntTensor *label_sizes,
-                        THIntTensor *sizes,
-                        int minibatch_size,
-                        THFloatTensor *costs,
-                        int blank_label) {
-
-    float *probs_ptr = probs->storage->data + probs->storageOffset;
+                       THFloatTensor *grads,
+                       THIntTensor *labels,
+                       THIntTensor *label_sizes,
+                       THIntTensor *sizes,
+                       int minibatch_size,
+                       THFloatTensor *costs,
+                       int blank_label)
+{
+    float *probs_ptr = THFloatTensor_data(probs);
     float *grads_ptr;
-    if (grads->storage) {
-            grads_ptr = grads->storage->data + grads->storageOffset;
+    if (THFloatTensor_storage(grads)) {
+        grads_ptr = THFloatTensor_data(grads);
     } else {
-            grads_ptr = NULL; // this will trigger the score forward code path
+        grads_ptr = NULL; // this will trigger the score forward code path
     }
 
-    int *sizes_ptr = sizes->storage->data + sizes->storageOffset;
-    int *labels_ptr = labels->storage->data + labels->storageOffset;
-    int *label_sizes_ptr = label_sizes->storage->data + label_sizes->storageOffset;
-    float *costs_ptr = costs->storage->data + costs->storageOffset;
+    int *sizes_ptr = THIntTensor_data(sizes);
+    int *labels_ptr = THIntTensor_data(labels);
+    int *label_sizes_ptr = THIntTensor_data(label_sizes);
+    float *costs_ptr = THFloatTensor_data(costs);
+
+    int probs_size = THFloatTensor_size(probs, 2);
 
     ctcOptions options;
     memset(&options, 0, sizeof(options));
@@ -49,64 +51,66 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
 
     size_t cpu_size_bytes;
     get_workspace_size(label_sizes_ptr, sizes_ptr,
-                       (int) probs->size[2], minibatch_size,
+                       probs_size, minibatch_size,
                        options, &cpu_size_bytes);
 
     float* cpu_workspace = (float*) new unsigned char[cpu_size_bytes];
 
     compute_ctc_loss(probs_ptr, grads_ptr,
                      labels_ptr, label_sizes_ptr,
-                     sizes_ptr, probs->size[2],
+                     sizes_ptr, probs_size,
                      minibatch_size, costs_ptr,
                      cpu_workspace, options);
 
     delete cpu_workspace;
     return 1;
 }
+
 #ifdef WARPCTC_ENABLE_GPU
-   extern "C" int gpu_ctc(THCudaTensor *probs,
-                           THCudaTensor *grads,
-                           THIntTensor *labels,
-                           THIntTensor *label_sizes,
-                           THIntTensor *sizes,
-                           int minibatch_size,
-                           THFloatTensor *costs,
-                           int blank_label) {
+extern "C" int gpu_ctc(THCudaTensor *probs,
+                       THCudaTensor *grads,
+                       THIntTensor *labels,
+                       THIntTensor *label_sizes,
+                       THIntTensor *sizes,
+                       int minibatch_size,
+                       THFloatTensor *costs,
+                       int blank_label)
+{
+    float *probs_ptr = THCudaTensor_data(state, probs);
+    float *grads_ptr;
+    if (THCudaTensor_storage(state, grads)) {
+        grads_ptr = THCudaTensor_data(state, grads);
+    } else {
+        grads_ptr = NULL; // this will trigger the score forward code path
+    }
 
-       float *probs_ptr = probs->storage->data + probs->storageOffset;
-       float *grads_ptr;
-       if (grads->storage) {
-               grads_ptr = grads->storage->data + grads->storageOffset;
-       } else {
-               grads_ptr = NULL; // this will trigger the score forward code path
-       }
+    int *sizes_ptr = THIntTensor_data(sizes);
+    int *labels_ptr = THIntTensor_data(labels);
+    int *label_sizes_ptr = THIntTensor_data(label_sizes);
+    float *costs_ptr = THFloatTensor_data(costs);
 
-       int *sizes_ptr = sizes->storage->data + sizes->storageOffset;
-       int *labels_ptr = labels->storage->data + labels->storageOffset;
-       int *label_sizes_ptr = label_sizes->storage->data + label_sizes->storageOffset;
-       float *costs_ptr = costs->storage->data + costs->storageOffset;
+    int probs_size = THFloatTensor_size(probs, 2);
 
-       ctcOptions options;
-       memset(&options, 0, sizeof(options));
-       options.loc = CTC_GPU;
-       options.blank_label = blank_label;
-       options.stream = THCState_getCurrentStream(state);
+    ctcOptions options;
+    memset(&options, 0, sizeof(options));
+    options.loc = CTC_GPU;
+    options.blank_label = blank_label;
+    options.stream = THCState_getCurrentStream(state);
 
-       size_t gpu_size_bytes;
-       get_workspace_size(label_sizes_ptr, sizes_ptr,
-                          (int) probs->size[2], minibatch_size,
-                          options, &gpu_size_bytes);
+    size_t gpu_size_bytes;
+    get_workspace_size(label_sizes_ptr, sizes_ptr,
+                       probs_size, minibatch_size,
+                       options, &gpu_size_bytes);
 
-       float* gpu_workspace;
-       THCudaMalloc(state, (void **) &gpu_workspace, gpu_size_bytes);
+    void* gpu_workspace = THCudaMalloc(state, gpu_size_bytes);
 
-       compute_ctc_loss(probs_ptr, grads_ptr,
-                        labels_ptr, label_sizes_ptr,
-                        sizes_ptr, probs->size[2],
-                        minibatch_size, costs_ptr,
-                        gpu_workspace, options);
+    compute_ctc_loss(probs_ptr, grads_ptr,
+                     labels_ptr, label_sizes_ptr,
+                     sizes_ptr, probs_size,
+                     minibatch_size, costs_ptr,
+                     gpu_workspace, options);
 
-       THCudaFree(state, (void *) gpu_workspace);
-       return 1;
-   }
+    THCudaFree(state, (void *) gpu_workspace);
+    return 1;
+}
 #endif

--- a/pytorch_binding/src/cpu_binding.h
+++ b/pytorch_binding/src/cpu_binding.h
@@ -4,4 +4,5 @@ int cpu_ctc(THFloatTensor *probs,
                         THIntTensor *label_sizes_ptr,
                         THIntTensor *sizes,
                         int minibatch_size,
-                        THFloatTensor *costs);
+                        THFloatTensor *costs,
+                        int blank_label);

--- a/pytorch_binding/src/gpu_binding.h
+++ b/pytorch_binding/src/gpu_binding.h
@@ -4,4 +4,5 @@ int gpu_ctc(THCudaTensor *probs,
                         THIntTensor *label_sizes_ptr,
                         THIntTensor *sizes,
                         int minibatch_size,
-                        THFloatTensor *costs);
+                        THFloatTensor *costs,
+                        int blank_label);

--- a/pytorch_binding/tests/test_cpu.py
+++ b/pytorch_binding/tests/test_cpu.py
@@ -17,7 +17,8 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('CPU_cost: %f' % costs.sum())
 
 
@@ -40,7 +41,8 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('CPU_cost: %f' % costs.sum())
 
 
@@ -62,7 +64,8 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('CPU_cost: %f' % costs.sum())
 
 

--- a/pytorch_binding/tests/test_gpu.py
+++ b/pytorch_binding/tests/test_gpu.py
@@ -18,7 +18,8 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -29,7 +30,8 @@ def test_simple():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 
@@ -54,7 +56,8 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -65,7 +68,8 @@ def test_medium(multiplier):
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 
@@ -89,7 +93,8 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('CPU_cost: %f' % costs.sum())
     probs = probs.clone().cuda()
     grads = torch.zeros(probs.size()).cuda()
@@ -100,7 +105,8 @@ def test_empty_label():
                      label_sizes,
                      sizes,
                      minibatch_size,
-                     costs)
+                     costs,
+                     0)
     print('GPU_cost: %f' % costs.sum())
     print(grads.view(grads.size(0) * grads.size(1), grads.size(2)))
 


### PR DESCRIPTION
Hi,
I'd like to send PR for updating for pytorch 0.5.0 and adding 'blank' option to point which index is blank label. Not sure the modification is rigorous or correct but it passed the tests/test_cpu.py and tests/test_gpu.py both.

Thanks,
Jinserk