### PR TITLE
Fix workspace allocation for cpu-mode to have correct size and deallocation

### DIFF
--- a/pytorch_binding/src/binding.cpp
+++ b/pytorch_binding/src/binding.cpp
@@ -54,7 +54,7 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
                        probs_size, minibatch_size,
                        options, &cpu_size_bytes);
 
-    float* cpu_workspace = (float*) new unsigned char[cpu_size_bytes];
+    float* cpu_workspace = new float[cpu_size_bytes / sizeof(float)];
 
     compute_ctc_loss(probs_ptr, grads_ptr,
                      labels_ptr, label_sizes_ptr,
@@ -62,7 +62,7 @@ extern "C" int cpu_ctc(THFloatTensor *probs,
                      minibatch_size, costs_ptr,
                      cpu_workspace, options);
 
-    delete cpu_workspace;
+    delete[] cpu_workspace;
     return 1;
 }
 


### PR DESCRIPTION
new[] belongs with delete[], and I think the length of the array stored by new[] will be wrong when delete[] goes to delete it if the array is re-cast, so just allocate this as a float array from the beginning.

I tested this by using warp-ctc pytorch bindings in cpu-mode using jemalloc, which previously was erroring due to this size mismatch issue.