### PR TITLE
Replace FFI to CUDAExtension for PyTorch 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -1,32 +1,18 @@
-# build.py
 import os
 import platform
 import sys
 from setuptools import setup, find_packages
 
-from torch.utils.ffi import create_extension
+from torch.utils.cpp_extension import BuildExtension, CppExtension
 import torch
 
-
-extra_compile_args = ['-std=c++11', '-fPIC', '-std=c99']
+extra_compile_args = ['-std=c++11', '-fPIC']
 warp_ctc_path = "../build"
-
-if torch.cuda.is_available() or "CUDA_HOME" in os.environ:
-    enable_gpu = True
-else:
-    print("Torch was not built with CUDA support, not building warp-ctc GPU extensions.")
-    enable_gpu = False
 
 if platform.system() == 'Darwin':
     lib_ext = ".dylib"
 else:
     lib_ext = ".so"
-
-headers = ['src/cpu_binding.h']
-
-if enable_gpu:
-    extra_compile_args += ['-DWARPCTC_ENABLE_GPU']
-    headers += ['src/gpu_binding.h']
 
 if "WARP_CTC_PATH" in os.environ:
     warp_ctc_path = os.environ["WARP_CTC_PATH"]
@@ -35,21 +21,36 @@ if not os.path.exists(os.path.join(warp_ctc_path, "libwarpctc" + lib_ext)):
            "Build warp-ctc and set WARP_CTC_PATH to the location of"
            " libwarpctc.so (default is '../build')").format(warp_ctc_path))
     sys.exit(1)
+
 include_dirs = [os.path.realpath('../include')]
 
-ffi = create_extension(
-    name='warpctc_pytorch._warp_ctc',
-    package=True,
-    language='c++',
-    headers=headers,
-    sources=['src/binding.cpp'],
-    with_cuda=enable_gpu,
-    include_dirs=include_dirs,
-    library_dirs=[os.path.realpath(warp_ctc_path)],
-    libraries=['warpctc'],
-    extra_link_args=['-Wl,-rpath,' + os.path.realpath(warp_ctc_path)],
-    extra_compile_args=extra_compile_args)
-ffi = ffi.distutils_extension()
+if torch.cuda.is_available() or "CUDA_HOME" in os.environ:
+    enable_gpu = True
+else:
+    print("Torch was not built with CUDA support, not building warp-ctc GPU extensions.")
+    enable_gpu = False
+
+if enable_gpu:
+    from torch.utils.cpp_extension import CUDAExtension
+
+    build_extension = CUDAExtension
+    extra_compile_args += ['-DWARPCTC_ENABLE_GPU']
+else:
+    build_extension = CppExtension
+
+ext_modules = [
+    build_extension(
+        name='warpctc_pytorch._warp_ctc',
+        language='c++',
+        sources=['src/binding.cpp'],
+        include_dirs=include_dirs,
+        library_dirs=[os.path.realpath(warp_ctc_path)],
+        libraries=['warpctc'],
+        extra_link_args=['-Wl,-rpath,' + os.path.realpath(warp_ctc_path)],
+        extra_compile_args=extra_compile_args
+    )
+]
+
 setup(
     name="warpctc_pytorch",
     version="0.1",
@@ -59,5 +60,6 @@ setup(
     author_email="jared.casper@baidu.com, sean.narenthiran@digitalreasoning.com",
     license="Apache",
     packages=find_packages(),
-    ext_modules=[ffi],
+    ext_modules=ext_modules,
+    cmdclass={'build_ext': BuildExtension}
 )

--- a/pytorch_binding/src/cpu_binding.h
+++ b/pytorch_binding/src/cpu_binding.h
@@ -1,3 +1,4 @@
+/*
 int cpu_ctc(THFloatTensor *probs,
                         THFloatTensor *grads,
                         THIntTensor *labels_ptr,
@@ -6,3 +7,13 @@ int cpu_ctc(THFloatTensor *probs,
                         int minibatch_size,
                         THFloatTensor *costs,
                         int blank_label);
+*/
+
+int cpu_ctc(torch::Tensor probs,
+            torch::Tensor grads,
+            torch::Tensor labels,
+            torch::Tensor label_sizes,
+            torch::Tensor sizes,
+            int minibatch_size,
+            torch::Tensor costs,
+            int blank_label); 

--- a/pytorch_binding/src/gpu_binding.h
+++ b/pytorch_binding/src/gpu_binding.h
@@ -1,3 +1,4 @@
+/*
 int gpu_ctc(THCudaTensor *probs,
                         THCudaTensor *grads,
                         THIntTensor *labels_ptr,
@@ -6,3 +7,13 @@ int gpu_ctc(THCudaTensor *probs,
                         int minibatch_size,
                         THFloatTensor *costs,
                         int blank_label);
+*/
+
+int gpu_ctc(torch::Tensor probs,
+            torch::Tensor grads,
+            torch::Tensor labels,
+            torch::Tensor label_sizes,
+            torch::Tensor sizes,
+            int minibatch_size,
+            torch::Tensor costs,
+            int blank_label);


### PR DESCRIPTION
Hi @SeanNaren,
I know that PyTorch 1.0.0 includes brand new CTCLoss, however, my old codes were not being trained well with it. I've discussed about the issue with @t-vi [here](https://github.com/pytorch/pytorch/issues/12201), but it's still unclear that the bpc metric he mentioned could make the difference. So I modified the old ffi extension interface of this project to the new CppExtension and CUDAExtention of PyTorch 1.0.0 to keep it with my legacy codes. I also know that you are going to make this project deprecated. It's totally up to your decision to merge this PR. Thank you!