### PR TITLE
Complication issue with pytorch 1.1

### DIFF
--- a/pytorch_binding/src/binding.cpp
+++ b/pytorch_binding/src/binding.cpp
@@ -7,7 +7,7 @@
 
 #ifdef WARPCTC_ENABLE_GPU
 	#include "ATen/cuda/CUDAContext.h"
-	#include "ATen/cuda/CUDAGuard.h"
+	#include <c10/cuda/CUDAGuard.h>
 	#include "ATen/cuda/CUDAEvent.h"
 
     #include "THC.h"


### PR DESCRIPTION
CUDAGuard.h has removed from latest ATen so, pytorch_binding compile will be failed. With this, problem will be fixed.