### PR TITLE
Change "grads" tensor to be pre-allocated

### DIFF
--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -14,16 +14,18 @@ def _assert_no_grad(tensor):
 
 class _CTC(Function):
     @staticmethod
-    def forward(ctx, acts, labels, act_lens, label_lens, grads, size_average=False,
+    def forward(ctx, acts, labels, act_lens, label_lens, size_average=False,
                 length_average=False, blank=0):
         is_cuda = True if acts.is_cuda else False
         acts = acts.contiguous()
+        acts_size = acts.size()
         loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
-#        grads = torch.zeros(acts.size()).type_as(acts)
         minibatch_size = acts.size(1)
         costs = torch.zeros(minibatch_size).cpu()
         loss_func(acts,
-                  grads,
+                  self.grad_tensor[:acts.size(0),
+                                   :acts.size(1),
+                                   :],
                   labels,
                   label_lens,
                   act_lens,
@@ -60,14 +62,16 @@ class CTCLoss(Module):
             in the batch. If `True`, supersedes `size_average`
             (default: `False`)
     """
-    def __init__(self, blank=0, size_average=False, length_average=False):
+    def __init__(self, batch_size, max_input_length, label_length,
+                 blank=0, size_average=False, length_average=False):
         super(CTCLoss, self).__init__()
         self.ctc = _CTC.apply
         self.blank = blank
         self.size_average = size_average
         self.length_average = length_average
+        self.grad_tensor = torch.zeros((max_input_length, batch_size, label_length))
 
-    def forward(self, acts, labels, act_lens, label_lens, grads):
+    def forward(self, acts, labels, act_lens, label_lens):
         """
         acts: Tensor of (seqLength x batch x outputDim) containing output from network
         labels: 1 dimensional Tensor containing all the targets of the batch in one sequence
@@ -78,5 +82,6 @@ class CTCLoss(Module):
         _assert_no_grad(labels)
         _assert_no_grad(act_lens)
         _assert_no_grad(label_lens)
-        return self.ctc(acts, labels, act_lens, label_lens, grads, self.size_average,
+        self.grad_tensor[:,:,:] = 0
+        return self.ctc(acts, labels, act_lens, label_lens, self.size_average,
                         self.length_average, self.blank)

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -48,7 +48,7 @@ class _CTC(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        return ctx.grads, None, None, None, None, None, None
+        return ctx.grads, None, None, None, None, None, None, None
 
 
 class CTCLoss(Module):

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -14,12 +14,12 @@ def _assert_no_grad(tensor):
 
 class _CTC(Function):
     @staticmethod
-    def forward(ctx, acts, labels, act_lens, label_lens, size_average=False,
+    def forward(ctx, acts, labels, act_lens, label_lens, grads, size_average=False,
                 length_average=False, blank=0):
         is_cuda = True if acts.is_cuda else False
         acts = acts.contiguous()
         loss_func = warp_ctc.gpu_ctc if is_cuda else warp_ctc.cpu_ctc
-        grads = torch.zeros(acts.size()).type_as(acts)
+#        grads = torch.zeros(acts.size()).type_as(acts)
         minibatch_size = acts.size(1)
         costs = torch.zeros(minibatch_size).cpu()
         loss_func(acts,

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -80,8 +80,8 @@ class CTCLoss(Module):
         _assert_no_grad(labels)
         _assert_no_grad(act_lens)
         _assert_no_grad(label_lens)
-        self.grads[:,:,:] = 0
+        self.grads[:, :, :] = 0
         self.grads = self.grads.to(acts.device)
         return self.ctc(acts, labels, act_lens, label_lens,
-                        self.grads[:acts.size(0),:acts.size(1),:],
+                        self.grads[:acts.size(0), :acts.size(1), :],
                         self.size_average, self.length_average, self.blank)

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -67,7 +67,7 @@ class CTCLoss(Module):
         self.size_average = size_average
         self.length_average = length_average
 
-    def forward(self, acts, labels, act_lens, label_lens):
+    def forward(self, acts, labels, act_lens, label_lens, grads):
         """
         acts: Tensor of (seqLength x batch x outputDim) containing output from network
         labels: 1 dimensional Tensor containing all the targets of the batch in one sequence
@@ -78,5 +78,5 @@ class CTCLoss(Module):
         _assert_no_grad(labels)
         _assert_no_grad(act_lens)
         _assert_no_grad(label_lens)
-        return self.ctc(acts, labels, act_lens, label_lens, self.size_average,
+        return self.ctc(acts, labels, act_lens, label_lens, grads, self.size_average,
                         self.length_average, self.blank)

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -81,6 +81,7 @@ class CTCLoss(Module):
         _assert_no_grad(act_lens)
         _assert_no_grad(label_lens)
         self.grads[:,:,:] = 0
+        self.grads = self.grads.to(acts.device)
         return self.ctc(acts, labels, act_lens, label_lens,
                         self.grads[:acts.size(0),:acts.size(1),:],
                         self.size_average, self.length_average, self.blank)


### PR DESCRIPTION
Currently, the _CTC.apply function allocates a "grads" tensor the same size as "acts" with every call of the function. In situations with large label size (Eastern languages, gram/word-level labels), this can cause a big slowdown, as we are consistently allocating and copying over data to the GPU for every call to CTC loss. Since this function is run in a training loop and we know the max batch size, max sequence length, and label length beforehand, we can allocate this gradient tensor in the CTCLoss function. When we call __forward__ we just zero the tensor and slice into the tensor for the current input's sequence length and batch size. This can cause up to a ~10x speed up in CTCLoss.

Possible complications:
- if you're really tight on memory space, keeping this always allocated might be a problem
- CTCLoss() \__init\__ call changes and requires updating codebases. 