### PR TITLE
Use grad_output in pytorch binding

### DIFF
--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -48,8 +48,8 @@ class _CTC(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        return ctx.grads, None, None, None, None, None, None
-
+        _grad_output = grad_output.to(ctx.grads.device)
+        return ctx.grads.mul_(_grad_output), None, None, None, None, None, None
 
 class CTCLoss(Module):
     """


### PR DESCRIPTION
It seems that _grad_output_ of [torch.autograd.Function](https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function) saves the gradient of the layer from the front of it. 
When i scaled CTC loss (like using AMP), i had to scale the graident too.