### PR TITLE
Add '-fopenmp'

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 from torch.utils.cpp_extension import BuildExtension, CppExtension
 import torch
 
-extra_compile_args = ['-std=c++14', '-fPIC']
+extra_compile_args = ['-std=c++14', '-fPIC', '-fopenmp']
 warp_ctc_path = "../build"
 
 if platform.system() == 'Darwin':


### PR DESCRIPTION
If `torch==1.6.0` is installed, following warning is raised when I try to build a wheel.

```console
$ python setup.py bdist_wheel
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/hdd/nishioka/warp-ctc/include -I/usr/local/cuda-10.2/include -I/opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include -I/opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/torch/csrc/api/include -I/opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/TH -I/opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/THC -I/usr/local/cuda/include -I/opt/pyenv/versions/3.8.5/include/python3.8 -c src/binding.cpp -o build/temp.linux-x86_64-3.8/src/binding.o -std=c++14 -fPIC -DWARPCTC_ENABLE_GPU -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=_warp_ctc -D_GLIBCXX_USE_CXX11_ABI=0
In file included from /opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/ATen/Parallel.h:149,
                 from /opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/torch/csrc/api/include/torch/utils.h:3,
                 from /opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/torch/csrc/api/include/torch/nn/cloneable.h:5,
                 from /opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/torch/csrc/api/include/torch/nn.h:3,
                 from /opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/torch/csrc/api/include/torch/all.h:7,
                 from /opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/torch/extension.h:4,
                 from src/binding.cpp:6:
/opt/pyenv/versions/3.8.5/lib/python3.8/site-packages/torch/include/ATen/ParallelOpenMP.h:84: warning: ignoring #pragma omp parallel [-Wunknown-pragmas]
 #pragma omp parallel for if ((end - begin) >= grain_size)

```

This is because `'-fopenmp'` is missing when building `src/binding.cpp`, so I've added it.